### PR TITLE
Prevent IE11 caching GET call in Angular 2

### DIFF
--- a/Abp/Framework/scripts/libs/abp.jquery.js
+++ b/Abp/Framework/scripts/libs/abp.jquery.js
@@ -13,7 +13,12 @@
         userOptions = userOptions || {};
 
         var options = $.extend(true, {}, abp.ajax.defaultOpts, userOptions);       
+        var oldBeforeSendOption = options.beforeSend;
         options.beforeSend = function(xhr) {
+            if (oldBeforeSendOption) { 
+                oldBeforeSendOption(xhr);
+            }
+
             xhr.setRequestHeader("Pragma", "no-cache");
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Expires", "Sat, 01 Jan 2000 00:00:00 GMT");

--- a/Abp/Framework/scripts/libs/abp.jquery.js
+++ b/Abp/Framework/scripts/libs/abp.jquery.js
@@ -12,7 +12,13 @@
     abp.ajax = function (userOptions) {
         userOptions = userOptions || {};
 
-        var options = $.extend(true, {}, abp.ajax.defaultOpts, userOptions);
+        var options = $.extend(true, {}, abp.ajax.defaultOpts, userOptions);       
+        options.beforeSend = function(xhr) {
+            xhr.setRequestHeader("Pragma", "no-cache");
+            xhr.setRequestHeader("Cache-Control", "no-cache");
+            xhr.setRequestHeader("Expires", "Sat, 01 Jan 2000 00:00:00 GMT");
+        };
+
         options.success = undefined;
         options.error = undefined;
 


### PR DESCRIPTION
See also https://github.com/aspnetboilerplate/abp-ng2-module/pull/10
In favor of https://github.com/aspnetboilerplate/bower-abp-resources/pull/4